### PR TITLE
add support for the princess IR panel.

### DIFF
--- a/homewizard_climate_websocket/api/api.py
+++ b/homewizard_climate_websocket/api/api.py
@@ -39,7 +39,7 @@ class HomeWizardClimateApi:
 
         if (
             resp.status_code == 200
-            and resp.headers.get("content-type") == "application/json"
+            and "application/json" in resp.headers.get("content-type")
             and "token" in resp.json()
         ):
             self._token = resp.json().get("token")
@@ -58,7 +58,7 @@ class HomeWizardClimateApi:
         )
         if (
             resp.status_code == 200
-            and resp.headers.get("content-type") == "application/json"
+            and "application/json" in resp.headers.get("content-type")
             and "devices" in resp.json()
         ):
             supported_device_types = [t.value for t in HomeWizardClimateDeviceType]

--- a/homewizard_climate_websocket/model/climate_device.py
+++ b/homewizard_climate_websocket/model/climate_device.py
@@ -11,7 +11,7 @@ class HomeWizardClimateDeviceType(Enum):
 
     HEATERFAN = "heaterfan"
     INFRAREDHEATER = "infraredheater"
-
+    HEATER = "heater"
 
 @dataclass_json
 @dataclass

--- a/homewizard_climate_websocket/model/climate_device.py
+++ b/homewizard_climate_websocket/model/climate_device.py
@@ -10,6 +10,7 @@ class HomeWizardClimateDeviceType(Enum):
     up by the API function get_devices"""
 
     HEATERFAN = "heaterfan"
+    INFRAREDHEATER = "infraredheater"
 
 
 @dataclass_json


### PR DESCRIPTION
Hi There,

Great work you did on the homewizard climate app. I got a Princess IR panel [this one](https://www.princesshome.eu/en-gb/princess-343350-smart-infrared-panel-heater-350-01.343350.01.001)
which uses the same endpoints as the tower heater you got.
Here is a complete list of the data it has:

```
{
  'type': 'infraredheater',
  'device': 'infraredheater/********',
  'state': {
    'power_on': False,
    'target_temperature': 23,
    'current_temperature': 24,
    'temperature_unit': 'celsius',
    'timer': 0,
    'mute': False,
    'error': [
      
    ],
    'timezone': 'Europe/Amsterdam CET-1CEST,M3.5.0,M10.5.0/3',
    'clock_format': '24h',
    'ext_mode': [
      
    ],
    'ext_current_temperature': None,
    'ext_target_temperature': None
  },
  'name': 'Infrared Heater',
  'online': True,
  'version': '1.00',
  'model': '1.6,HWC-INFH',
  'hardware_version': '1.00',
  'wifi_ssid': '*********',
  'wifi_strength': 100
}
```
Tested and working calls:

ws.turn_on()
ws.turn_off()
ws.set_target_temperature()
